### PR TITLE
Check error

### DIFF
--- a/shellescape/datasource_shellescape_string.go
+++ b/shellescape/datasource_shellescape_string.go
@@ -26,7 +26,9 @@ func dataSourceShellescapeQuote() *schema.Resource {
 
 func dataSourceShellescapeQuoteRead(d *schema.ResourceData, m interface{}) error {
 	quoted := shellescape.Quote(d.Get("string").(string))
-	d.Set("quoted", quoted)
+	if err := d.Set("quoted", quoted); err != nil {
+		return err
+	}
 	d.SetId(strconv.Itoa(hashcode.String(quoted)))
 	return nil
 }


### PR DESCRIPTION
> shellescape/datasource_shellescape_string.go:29:7: Error return value of `d.Set` is not checked (errcheck)
> 	d.Set("quoted", quoted)
> 