### PR TITLE
Use latest terraform in test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,4 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.8.0-beta1
       - run: go test ./...


### PR DESCRIPTION
https://github.com/bgpat/terraform-provider-shellescape/commit/a99e0096816e1c1e3e141bb183ac24ef3a418250
v1.8.x is already released.